### PR TITLE
fix build with qt 5.5

### DIFF
--- a/src/configuration/qgvariantutils.cpp
+++ b/src/configuration/qgvariantutils.cpp
@@ -39,6 +39,7 @@
 #include <QtCore/QDebug>
 #include <QtCore/QUrl>
 #include <QtCore/QStringList>
+#include <QDataStream>
 
 #include "qgvariantutils.h"
 


### PR DESCRIPTION
src/configuration/qgvariantutils.cpp:99:26: error: variable 'QDataStream s' has initializer but incomplete type
             QDataStream s(&a, QIODevice::ReadOnly);
                          ^

Signed-off-by: Andreas Müller schnitzeltony@googlemail.com
